### PR TITLE
update pandas functions to reduce warnings

### DIFF
--- a/simba/tools/_pbg.py
+++ b/simba/tools/_pbg.py
@@ -211,40 +211,35 @@ def gen_graph(list_CP=None,
             columns=['alias'],
             data=[f'{k}.{x}' for x in range(len(dict_cells[k]))])
         settings.pbg_params['entities'][k] = {'num_partitions': 1}
-        entity_alias = entity_alias.append(dict_df_cells[k],
-                                           ignore_index=False)
+        entity_alias = pd.concat([entity_alias, dict_df_cells[k]], ignore_index=False)
     if(len(ids_genes) > 0):
         df_genes = pd.DataFrame(
                 index=ids_genes,
                 columns=['alias'],
                 data=[f'{prefix_G}.{x}' for x in range(len(ids_genes))])
         settings.pbg_params['entities'][prefix_G] = {'num_partitions': 1}
-        entity_alias = entity_alias.append(df_genes,
-                                           ignore_index=False)
+        entity_alias = pd.concat([entity_alias, df_genes], ignore_index=False)
     if(len(ids_peaks) > 0):
         df_peaks = pd.DataFrame(
                 index=ids_peaks,
                 columns=['alias'],
                 data=[f'{prefix_P}.{x}' for x in range(len(ids_peaks))])
         settings.pbg_params['entities'][prefix_P] = {'num_partitions': 1}
-        entity_alias = entity_alias.append(df_peaks,
-                                           ignore_index=False)
+        entity_alias = pd.concat([entity_alias, df_peaks], ignore_index=False)
     if(len(ids_kmers) > 0):
         df_kmers = pd.DataFrame(
                 index=ids_kmers,
                 columns=['alias'],
                 data=[f'{prefix_K}.{x}' for x in range(len(ids_kmers))])
         settings.pbg_params['entities'][prefix_K] = {'num_partitions': 1}
-        entity_alias = entity_alias.append(df_kmers,
-                                           ignore_index=False)
+        entity_alias = pd.concat([entity_alias, df_kmers], ignore_index=False)
     if(len(ids_motifs) > 0):
         df_motifs = pd.DataFrame(
             index=ids_motifs,
             columns=['alias'],
             data=[f'{prefix_M}.{x}' for x in range(len(ids_motifs))])
         settings.pbg_params['entities'][prefix_M] = {'num_partitions': 1}
-        entity_alias = entity_alias.append(df_motifs,
-                                           ignore_index=False)
+        entity_alias = pd.concat([entity_alias, df_motifs], ignore_index=False)
 
     # generate edges
     dict_graph_stats = dict()
@@ -405,8 +400,7 @@ def gen_graph(list_CP=None,
                     {'source': key,
                      'destination': prefix_G,
                      'n_edges': df_edges_x.shape[0]}
-                df_edges = df_edges.append(df_edges_x,
-                                           ignore_index=True)
+                df_edges = pd.concat([df_edges, df_edges_x], ignore_index=True)
                 settings.pbg_params['relations'].append(
                     {'name': f'r{id_r}',
                      'lhs': f'{key}',

--- a/simba/tools/_post_training.py
+++ b/simba/tools/_post_training.py
@@ -137,10 +137,7 @@ class SimbaEmbed:
         percentile = self.percentile
         list_percentile = self.list_percentile
         X_all = adata_ref.X.copy()
-        # obs_all = pd.DataFrame(
-        #     data=['ref']*adata_ref.shape[0],
-        #     index=adata_ref.obs.index,
-        #     columns=['id_dataset'])
+
         obs_all = adata_ref.obs.copy()
         obs_all['id_dataset'] = ['ref']*adata_ref.shape[0]
         for i, adata_query in enumerate(list_adata_query):
@@ -178,15 +175,11 @@ class SimbaEmbed:
                     n_top=n_top,
                     )
             X_all = np.vstack((X_all, adata_query.layers['softmax']))
-            # obs_all = obs_all.append(
-            #     pd.DataFrame(
-            #         data=[f'query_{i}']*adata_query.shape[0],
-            #         index=adata_query.obs.index,
-            #         columns=['id_dataset'])
-            #         )
+
             obs_query = adata_query.obs.copy()
             obs_query['id_dataset'] = [f'query_{i}']*adata_query.shape[0]
-            obs_all = obs_all.append(obs_query, ignore_index=False)
+            obs_all = pd.concat([obs_all, obs_query], ignore_index=False)
+            
         adata_all = ad.AnnData(X=X_all,
                                obs=obs_all)
         return adata_all


### PR DESCRIPTION
@huidongchen - swapped out a few `.append` functions (in [**`_pbg.py`**](https://github.com/pinellolab/simba/blob/master/simba/tools/_pbg.py)) and [**`_post_training.py`**](https://github.com/pinellolab/simba/blob/master/simba/tools/_post_training.py)) in favor of using `pd.concat` to get rid of the deprecation warning from pandas. What do you think?